### PR TITLE
Update views.py

### DIFF
--- a/src/piaf/views.py
+++ b/src/piaf/views.py
@@ -80,7 +80,10 @@ class AdminDatasetView(SuperUserMixin, TemplateView):
                 if i % 5 == 0:
                     batch = ParagraphBatch()
                     batch.save()
-                Paragraph(batch=batch, article=article, text=p["context"]).save()
+                paragraph=Paragraph(batch=batch, article=article, text=p["context"])
+                paragraph.save()
+                for question in p["qas"]:
+                    Question(paragraph=paragraph, text=question["question"]).save()
         context = {"count_inserted_articles": len(data)}
         return self.render_to_response(context=context)
 


### PR DESCRIPTION
If a dataset in json format has questions for a paragraph, it will load them as well. This is useful for the second part of the annotation (collect answers to questions).

Note that this does not load answers that might be in the dataset, only the questions.   

Related to the second part of the annotation process (Annotation2.vue for the additional answer collection), I have tried to get rid of the congratulatory message after each answer collection, as it slows down the annotation process. I have found no straightforward way to do it. When I managed to do it using different methods (goToAnnotation after mounting on Bravo.vue for example), I was met with a bug (mostly for non-admin users I believe) where the question would not match the paragraph. Any help on this would be appreciated. 