### PR TITLE
adding SHELL := /bin/bash plus other thingies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+SHELL := /bin/bash
 DC    := 'docker-compose'
 export WEBPACK_ENVIRONMENT_PRODUCTION=True
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ source venv/bin/activate
 pip install -r requirements.txt
 ```
 
+Secondly, install Vue cli (if needed):
+
+```bash
+npm install -g @vue/cli@latest
+```
+
 Then compile the frontend:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ pip install -r requirements.txt
 Secondly, install Vue cli (if needed):
 
 ```bash
-npm install -g @vue/cli@latest
+sudo npm install -g @vue/cli@latest # In Linux/Debian
 ```
 
 Then compile the frontend:


### PR DESCRIPTION
It was not working with the shebang. I was getting this error when `makefile build-statics`: 
`/bin/sh: 1: [[: not found` # still calling `sh`

So I explicitly added with `SHELL := /bin/bash` and it is working :shrug: