### PR TITLE
Added npm install before npm run build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ build-statics:
 	if [[ -f "README.md" ]]; then \
 		mkdir src/piaf/front/static; \
 	fi; \
-	cd src/piaf/front/static && npm run build
+	cd src/piaf/front/static && npm install && npm run build
 
 test:
 	DATABASE_URL=pgsql://localhost/piaf?sslmode=disable src/manage.py test piaf

--- a/README_without_docker.md
+++ b/README_without_docker.md
@@ -38,12 +38,6 @@ source venv/bin/activate
 pip install -r requirements.txt
 ```
 
-Secondly, install Vue cli (if needed):
-
-```bash
-sudo npm install -g @vue/cli@latest # In Linux/Debian
-```
-
 Then compile the frontend:
 
 ```bash


### PR DESCRIPTION
hi! 
In order to run the build of the frontend, I added to the Makefile the command needed to install the dependencies, as it is also done here https://github.com/etalab/piaf/blob/9d1307268dddc7be60e11f1a2fbd203c28ecb2fc/tools/dev-webpack.sh#L17

Once the modules required installed, the building runs without problems. There are some differences with what is done in the above `dev-webpack.sh` file, namely the working directory used in the `Makefile` and the `dev-webpack` files are different.

As a side note, the Dockerfile seems obsolete (it references paths that no longer exist) plus I think that it is not used by `docker-compose.yml`?